### PR TITLE
Turn off reporting on externals by default.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 # master
 - Don't report unused optional arguments for functions annotated `@live` or `@genType`.
 - Add support for `@live` or `dead` at toplevel in a type declaration. Equivalent to annotating all the record fields / variant cases.
+- Turn off dead code reporting on externals by default. Add option `-externals` to turn back on.
 
 # 2.17.0
 - Give explicit error message for ast cases not implemented.

--- a/examples/deadcode/src/deadcode.txt
+++ b/examples/deadcode/src/deadcode.txt
@@ -7,7 +7,6 @@
   addVariantCaseDeclaration R2 AutoAnnotate.res:14:2 path:+AutoAnnotate.annotatedVariant
   addVariantCaseDeclaration R4 AutoAnnotate.res:15:2 path:+AutoAnnotate.annotatedVariant
   Scanning BootloaderResource.cmt Source:BootloaderResource.res
-  addValueDeclaration +read BootloaderResource.res:3:0 path:+BootloaderResource
   Scanning BucklescriptAnnotations.cmt Source:BucklescriptAnnotations.res
   addValueDeclaration +bar BucklescriptAnnotations.res:25:4 path:+BucklescriptAnnotations
   addValueDeclaration +f BucklescriptAnnotations.res:26:6 path:+BucklescriptAnnotations
@@ -155,8 +154,6 @@
   addValueDeclaration +foo DeadTest.res:90:8 path:+DeadTest
   addValueDeclaration +bar DeadTest.res:94:4 path:+DeadTest
   addValueDeclaration +withDefaultValue DeadTest.res:96:4 path:+DeadTest
-  addValueDeclaration +unsafe_string1 DeadTest.res:98:0 path:+DeadTest
-  addValueDeclaration +unsafe_string2 DeadTest.res:101:2 path:+DeadTest.Ext_buffer
   addValueDeclaration +reasonResource DeadTest.res:108:40 path:+DeadTest.LazyDynamicallyLoadedComponent
   addValueDeclaration +makeProps DeadTest.res:108:40 path:+DeadTest.LazyDynamicallyLoadedComponent
   addValueDeclaration +make DeadTest.res:108:40 path:+DeadTest.LazyDynamicallyLoadedComponent
@@ -435,7 +432,6 @@
   addValueDeclaration +k FirstClassModules.res:29:8 path:+FirstClassModules.M.InnerModule2
   addValueDeclaration +k3 FirstClassModules.res:33:8 path:+FirstClassModules.M.InnerModule3
   addValueDeclaration +u FirstClassModules.res:40:8 path:+FirstClassModules.M.Z
-  addValueDeclaration +f FirstClassModules.res:43:2 path:+FirstClassModules.M
   addValueDeclaration +x FirstClassModules.res:44:6 path:+FirstClassModules.M
   addValueDeclaration +firstClassModule FirstClassModules.res:51:4 path:+FirstClassModules
   addValueDeclaration +testConvert FirstClassModules.res:54:4 path:+FirstClassModules
@@ -605,12 +601,6 @@
   Scanning IgnoreInterface.cmt Source:IgnoreInterface.res
   Scanning IgnoreInterface.cmti Source:IgnoreInterface.resi
   Scanning ImmutableArray.cmt Source:ImmutableArray.res
-  addValueDeclaration +fromT ImmutableArray.res:5:2 path:+ImmutableArray.Array
-  addValueDeclaration +fromTp ImmutableArray.res:6:2 path:+ImmutableArray.Array
-  addValueDeclaration +fromTT ImmutableArray.res:7:2 path:+ImmutableArray.Array
-  addValueDeclaration +toT ImmutableArray.res:8:2 path:+ImmutableArray.Array
-  addValueDeclaration +toTp ImmutableArray.res:9:2 path:+ImmutableArray.Array
-  addValueDeclaration +toT2 ImmutableArray.res:10:2 path:+ImmutableArray.Array
   addValueDeclaration +fromArray ImmutableArray.res:14:6 path:+ImmutableArray.Array
   addValueDeclaration +toArray ImmutableArray.res:16:6 path:+ImmutableArray.Array
   addValueDeclaration +length ImmutableArray.res:20:6 path:+ImmutableArray.Array
@@ -671,12 +661,6 @@
   addValueDeclaration +cmp ImmutableArray.res:112:6 path:+ImmutableArray.Array
   addValueDeclaration +eqU ImmutableArray.res:114:6 path:+ImmutableArray.Array
   addValueDeclaration +eq ImmutableArray.res:115:6 path:+ImmutableArray.Array
-  addValueDeclaration +fromT ImmutableArray.res:5:2 path:+ImmutableArray
-  addValueDeclaration +fromTp ImmutableArray.res:6:2 path:+ImmutableArray
-  addValueDeclaration +fromTT ImmutableArray.res:7:2 path:+ImmutableArray
-  addValueDeclaration +toT ImmutableArray.res:8:2 path:+ImmutableArray
-  addValueDeclaration +toTp ImmutableArray.res:9:2 path:+ImmutableArray
-  addValueDeclaration +toT2 ImmutableArray.res:10:2 path:+ImmutableArray
   addValueDeclaration +fromArray ImmutableArray.res:14:6 path:+ImmutableArray
   addValueDeclaration +toArray ImmutableArray.res:16:6 path:+ImmutableArray
   addValueDeclaration +length ImmutableArray.res:20:6 path:+ImmutableArray
@@ -1085,20 +1069,16 @@
   addValueDeclaration +eqU ImmutableArray.resi:109:0 path:ImmutableArray
   addValueDeclaration +eq ImmutableArray.resi:110:0 path:ImmutableArray
   Scanning ImportHookDefault.cmt Source:ImportHookDefault.res
-  addValueDeclaration +makeProps ImportHookDefault.res:6:0 path:+ImportHookDefault
   addValueDeclaration +make ImportHookDefault.res:6:0 path:+ImportHookDefault
-  addValueDeclaration +make2Props ImportHookDefault.res:13:0 path:+ImportHookDefault
   addValueDeclaration +make2 ImportHookDefault.res:13:0 path:+ImportHookDefault
   addRecordLabelDeclaration name ImportHookDefault.res:2:2 path:+ImportHookDefault.person
   addRecordLabelDeclaration age ImportHookDefault.res:3:2 path:+ImportHookDefault.person
   Scanning ImportHooks.cmt Source:ImportHooks.res
-  addValueDeclaration +makeProps ImportHooks.res:13:0 path:+ImportHooks
   addValueDeclaration +make ImportHooks.res:13:0 path:+ImportHooks
   addValueDeclaration +foo ImportHooks.res:20:0 path:+ImportHooks
   addRecordLabelDeclaration name ImportHooks.res:3:2 path:+ImportHooks.person
   addRecordLabelDeclaration age ImportHooks.res:4:2 path:+ImportHooks.person
   Scanning ImportIndex.cmt Source:ImportIndex.res
-  addValueDeclaration +makeProps ImportIndex.res:2:0 path:+ImportIndex
   addValueDeclaration +make ImportIndex.res:2:0 path:+ImportIndex
   Scanning ImportJsValue.cmt Source:ImportJsValue.res
   addValueDeclaration +round ImportJsValue.res:1:0 path:+ImportJsValue
@@ -1106,7 +1086,6 @@
   addValueDeclaration +returnMixedArray ImportJsValue.res:23:0 path:+ImportJsValue
   addValueDeclaration +roundedNumber ImportJsValue.res:27:4 path:+ImportJsValue
   addValueDeclaration +areaValue ImportJsValue.res:30:4 path:+ImportJsValue
-  addValueDeclaration +getProp ImportJsValue.res:37:2 path:+ImportJsValue.AbsoluteValue
   addValueDeclaration +getAbs ImportJsValue.res:40:6 path:+ImportJsValue.AbsoluteValue
   addValueDeclaration +useGetProp ImportJsValue.res:47:4 path:+ImportJsValue
   addValueDeclaration +useGetAbs ImportJsValue.res:50:4 path:+ImportJsValue
@@ -1136,7 +1115,6 @@
   addRecordLabelDeclaration text ImportMyBanner.res:5:16 path:+ImportMyBanner.message
   addValueReference ImportMyBanner.res:20:4 --> ImportMyBanner.res:7:0
   Scanning JSResource.cmt Source:JSResource.res
-  addValueDeclaration +jSResource JSResource.res:3:0 path:+JSResource
   Scanning LetPrivate.cmt Source:LetPrivate.res
   addValueDeclaration +y LetPrivate.res:7:4 path:+LetPrivate
   addValueDeclaration +x LetPrivate.res:3:6 path:+LetPrivate.local_1
@@ -1483,8 +1461,6 @@
   addTypeReference RepeatedLabel.res:12:16 --> RepeatedLabel.res:8:2
   addValueReference RepeatedLabel.res:14:7 --> RepeatedLabel.res:12:4
   Scanning RequireCond.cmt Source:RequireCond.res
-  addValueDeclaration +make RequireCond.res:1:0 path:+RequireCond
-  addValueDeclaration +either RequireCond.res:11:0 path:+RequireCond
   Scanning Shadow.cmt Source:Shadow.res
   addValueDeclaration +test Shadow.res:2:4 path:+Shadow
   addValueDeclaration +test Shadow.res:5:4 path:+Shadow
@@ -2049,8 +2025,6 @@ File References
   Dead Value +DeadTest.LazyDynamicallyLoadedComponent2.+makeProps: 0 references () [0]
   Dead Value +DeadTest.LazyDynamicallyLoadedComponent2.+reasonResource: 0 references () [0]
   Live Value +DeadTest.LazyDynamicallyLoadedComponent.+make: 1 references (DeadTest.res:127:4) [0]
-  Dead Value +DeadTest.Ext_buffer.+unsafe_string2: 0 references () [0]
-  Dead Value +DeadTest.+unsafe_string1: 0 references () [0]
   Dead Value +DeadTest.+withDefaultValue: 0 references () [0]
   Dead Value +DeadTest.+bar: 0 references () [0]
   Dead Value +DeadTest.+foo: 0 references () [1]
@@ -2128,7 +2102,6 @@ File References
   Live Value +FirstClassModules.+testConvert: 0 references () [0]
   Live Value +FirstClassModules.+firstClassModule: 0 references () [0]
   Live Value +FirstClassModules.M.+x: 1 references (FirstClassModules.res:2:2) [0]
-  Live Value +FirstClassModules.M.+f: 1 references (FirstClassModules.res:4:2) [0]
   Live Value +FirstClassModules.M.Z.+u: 1 references (FirstClassModules.res:37:4) [0]
   Live Value +FirstClassModules.M.InnerModule3.+k3: 1 references (FirstClassModules.res:14:4) [0]
   Live Value +FirstClassModules.M.InnerModule2.+k: 1 references (FirstClassModules.res:10:4) [0]
@@ -2277,8 +2250,6 @@ File References
   Live RecordLabel +RepeatedLabel.tabState.a: 1 references (RepeatedLabel.res:12:16) [0]
   Dead RecordLabel +RepeatedLabel.userData.b: 0 references () [0]
   Dead RecordLabel +RepeatedLabel.userData.a: 0 references () [0]
-  Dead Value +RequireCond.+either: 0 references () [0]
-  Dead Value +RequireCond.+make: 0 references () [0]
   Dead Value +Shadow.M.+test: 0 references () [0]
   Live Value +Shadow.M.+test: 0 references () [0]
   Live Value +Shadow.+test: 0 references () [0]
@@ -2458,7 +2429,6 @@ File References
   Live Value +VariantsWithPayload.+testWithPayload: 0 references () [0]
   Live RecordLabel +VariantsWithPayload.payload.y: 2 references (VariantsWithPayload.res:26:74, VariantsWithPayload.res:44:72) [0]
   Live RecordLabel +VariantsWithPayload.payload.x: 2 references (VariantsWithPayload.res:26:57, VariantsWithPayload.res:44:55) [0]
-  Live Value +BootloaderResource.+read: 1 references (DeadTest.res:108:40) [0]
   Live Value +DeadExn.+eInside: 1 references (DeadExn.res:12:7) [0]
   Dead Value +DeadExn.+eToplevel: 0 references () [0]
   Dead Exception +DeadExn.DeadE: 0 references () [0]
@@ -2562,7 +2532,6 @@ File References
   Live Value +ImportJsValue.+useGetProp: 0 references () [0]
   Live Value +ImportJsValue.AbsoluteValue.+getAbs: 1 references (ImportJsValue.res:50:4) [1]
   Live Value +ImportJsValue.AbsoluteValue.+getAbs: 1 references (ImportJsValue.res:40:6) [0]
-  Live Value +ImportJsValue.AbsoluteValue.+getProp: 2 references (ImportJsValue.res:47:4, UseImportJsValue.res:2:4) [0]
   Live Value +ImportJsValue.+areaValue: 0 references () [0]
   Live Value +ImportJsValue.+roundedNumber: 0 references () [0]
   Live Value +ImportJsValue.+returnMixedArray: 0 references () [0]
@@ -2570,7 +2539,6 @@ File References
   Dead RecordLabel +ImportJsValue.point.y: 0 references () [0]
   Dead RecordLabel +ImportJsValue.point.x: 0 references () [0]
   Live Value +ImportJsValue.+round: 1 references (ImportJsValue.res:27:4) [0]
-  Live Value +JSResource.+jSResource: 2 references (DeadTest.res:108:40, DeadTest.res:113:6) [0]
   Live Value +NestedModulesInSignature.Universe.+theAnswer: 1 references (NestedModulesInSignature.resi:2:2) [0]
 
   Warning Unused Argument
@@ -2647,12 +2615,6 @@ File References
   Dead Value +ImmutableArray.+length: 0 references () [0]
   Dead Value +ImmutableArray.+toArray: 0 references () [0]
   Live Value +ImmutableArray.+fromArray: 1 references (ImmutableArray.resi:9:0) [0]
-  Dead Value +ImmutableArray.+toT2: 0 references () [0]
-  Dead Value +ImmutableArray.+toTp: 0 references () [0]
-  Live Value +ImmutableArray.+toT: 1 references (ImmutableArray.res:14:6) [0]
-  Dead Value +ImmutableArray.+fromTT: 0 references () [0]
-  Dead Value +ImmutableArray.+fromTp: 0 references () [0]
-  Live Value +ImmutableArray.+fromT: 1 references (ImmutableArray.res:24:6) [0]
 
   Warning Redundant Optional Argument
   File "./OptArg.res", line 26, characters 0-70
@@ -3028,22 +2990,6 @@ File References
   <-- line 96
   @dead("+withDefaultValue") let withDefaultValue = (~paramWithDefault=3, y) => paramWithDefault + y
 
-  Warning Dead Value
-  File "./DeadTest.res", line 98, characters 0-74
-  +unsafe_string1 is never used
-  <-- line 98
-  @dead("+unsafe_string1") external unsafe_string1: (bytes, int, int) => Digest.t = "caml_md5_string"
-
-  Warning Dead Module
-  File "./DeadTest.res", line 100, characters 7-182
-  +DeadTest.Ext_buffer is a dead module as all its items are dead.
-
-  Warning Dead Value
-  File "./DeadTest.res", line 101, characters 2-76
-  Ext_buffer.+unsafe_string2 is never used
-  <-- line 101
-    @dead("Ext_buffer.+unsafe_string2") external unsafe_string2: (bytes, int, int) => Digest.t = "caml_md5_string"
-
   Warning Dead Module
   File "./DeadTest.res", line 112, characters 7-413
   +DeadTest.LazyDynamicallyLoadedComponent2 is a dead module as all its items are dead.
@@ -3287,30 +3233,6 @@ File References
   +r is never used
   <-- line 7
   @dead("+r") let r: record
-
-  Warning Dead Value
-  File "./ImmutableArray.res", line 6, characters 2-63
-  +fromTp is never used
-  <-- line 6
-    @dead("+fromTp") external fromTp: t<('a, 'b)> => array<('a, 'b)> = "%identity"
-
-  Warning Dead Value
-  File "./ImmutableArray.res", line 7, characters 2-61
-  +fromTT is never used
-  <-- line 7
-    @dead("+fromTT") external fromTT: t<t<'a>> => array<array<'a>> = "%identity"
-
-  Warning Dead Value
-  File "./ImmutableArray.res", line 9, characters 2-61
-  +toTp is never used
-  <-- line 9
-    @dead("+toTp") external toTp: array<('a, 'b)> => t<('a, 'b)> = "%identity"
-
-  Warning Dead Value
-  File "./ImmutableArray.res", line 10, characters 2-59
-  +toT2 is never used
-  <-- line 10
-    @dead("+toT2") external toT2: array2<'a> => (t<'a>, t<'a>) = "%identity"
 
   Warning Dead Value
   File "./ImmutableArray.res", line 16, characters 2-41
@@ -4326,22 +4248,6 @@ File References
   <-- line 9
     @dead("tabState.f") f: string,
 
-  Warning Dead Module
-  File "./RequireCond.res", line 0, characters 0-0
-  +RequireCond is a dead module as all its items are dead.
-
-  Warning Dead Value
-  File "./RequireCond.res", line 1, characters 0-254
-  +make is never used
-  <-- line 1
-  @dead("+make") @module
-
-  Warning Dead Value
-  File "./RequireCond.res", line 11, characters 0-290
-  +either is never used
-  <-- line 11
-  @dead("+either") @module
-
   Warning Dead Value
   File "./Shadow.res", line 11, characters 2-22
   M.+test is never used
@@ -4598,4 +4504,4 @@ File References
   <-- line 96
   type variant1Object = | @dead("variant1Object.R") R(payload)
   
-  Analysis reported 341 issues (Warning Dead Exception:1, Warning Dead Module:26, Warning Dead Type:88, Warning Dead Value:208, Warning Dead Value With Side Effects:2, Warning Redundant Optional Argument:5, Warning Unused Argument:11)
+  Analysis reported 331 issues (Warning Dead Exception:1, Warning Dead Module:24, Warning Dead Type:88, Warning Dead Value:200, Warning Dead Value With Side Effects:2, Warning Redundant Optional Argument:5, Warning Unused Argument:11)

--- a/src/DeadCommon.ml
+++ b/src/DeadCommon.ml
@@ -12,7 +12,7 @@ module Config = struct
   (* Turn on type analysis *)
   let analyzeTypes = ref true
 
-  let analyzeExternals = true
+  let analyzeExternals = ref false
 
   let reportUnderscore = false
 

--- a/src/Reanalyze.ml
+++ b/src/Reanalyze.ml
@@ -184,6 +184,9 @@ let cli () =
       ( "-experimental",
         Arg.Unit setExperimental,
         "Turn on experimental analyses (this option is currently unused)" );
+      ( "-externals",
+        Arg.Unit (fun () -> DeadCommon.Config.analyzeExternals := true),
+        "Report on externals in dead code analysis" );
       ( "-live-names",
         Arg.String (fun s -> setLiveNames s),
         "comma-separated-names Consider all values with the give names as live"


### PR DESCRIPTION
This resolved some issues with e.g `@inline` annotations which cannot be silenced as the compiler's PPX ignores all the existing annotations and turns them into externals with a special encoding.

Fixes https://github.com/rescript-association/reanalyze/issues/136