### PR TITLE
Don't report on dead values inside a function annotated `@dead`.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,7 @@
 # master
 Add support for `[@warning "-unused-value-declaration"]`.
+Don't report on dead values inside a function annotated `@dead`.
+
 # 2.19.0
 - Don't report redundant optional arguments on functions annotated `@live`.
 

--- a/examples/deadcode/src/DeadTest.res
+++ b/examples/deadcode/src/DeadTest.res
@@ -179,3 +179,9 @@ module WithInclude: {
 
 Js.log(WithInclude.A)
 
+@dead
+let funWithInnerVars = () => {
+  let x = 34
+  let y = 36
+  x + y
+}


### PR DESCRIPTION
Fixes https://github.com/rescript-association/reanalyze/issues/156