### PR TITLE
Add exception examples with pipe.

### DIFF
--- a/examples/deadcode/src/exception.txt
+++ b/examples/deadcode/src/exception.txt
@@ -112,7 +112,15 @@
   Toplevel expression might raise exit (Exn.res:189:7) and is not annotated with @raises exit
 
   Exception Analysis
+  File "./Exn.res", line 199, characters 44-46
+  expression does not raise and is annotated with redundant @doesNotRaise
+
+  Exception Analysis
+  File "./Exn.res", line 199, characters 4-21
+  onResultPipeWrong might raise Assert_failure (Exn.res:199:48) and is not annotated with @raises Assert_failure
+
+  Exception Analysis
   File "./ExnA.res", line 1, characters 4-7
   bar might raise Not_found (ExnA.res:1:16) and is not annotated with @raises Not_found
   
-  Analysis reported 29 issues (Exception Analysis:29)
+  Analysis reported 31 issues (Exception Analysis:31)

--- a/examples/deadcode/src/exception/Exn.bs.js
+++ b/examples/deadcode/src/exception/Exn.bs.js
@@ -108,6 +108,10 @@ export {
   exits ,
   redundantAnnotation ,
   _x ,
+  onFunction ,
+  onResult ,
+  onFunctionPipe ,
+  onResultPipeWrong ,
   
 }
 /* catches1 Not a pure module */

--- a/examples/deadcode/src/exception/Exn.res
+++ b/examples/deadcode/src/exception/Exn.res
@@ -187,3 +187,13 @@ let () = raise(A)
 raise(Not_found)
 
 true ? exits() : ()
+
+// Examples with pipe
+
+let onFunction = () => (@doesNotRaise Belt.Array.getExn)([], 0)
+
+let onResult = () => @doesNotRaise Belt.Array.getExn([], 0)
+
+let onFunctionPipe = () => []->(@doesNotRaise Belt.Array.getExn)(0)
+
+let onResultPipeWrong = () => @doesNotRaise []->Belt.Array.getExn(0)


### PR DESCRIPTION
There's an issue when trying to annotate the result of pipe.

See https://github.com/rescript-association/reanalyze/issues/164