### PR TITLE
Variants location adjustment to insert annotations.

### DIFF
--- a/examples/deadcode/src/deadcode.txt
+++ b/examples/deadcode/src/deadcode.txt
@@ -2722,7 +2722,7 @@ File References
     | @dead("annotatedVariant.R2") R2(r2, r3)
 
   Warning Dead Type
-  File "AutoAnnotate.res", line 15, characters 2-10
+  File "AutoAnnotate.res", line 15, characters 4-10
   annotatedVariant.R4 is a variant case which is never constructed
   <-- line 15
     | @dead("annotatedVariant.R4") R4(r4)
@@ -3104,7 +3104,7 @@ File References
     @dead("Ext_buffer.+x") let x = 42
 
   Warning Dead Type
-  File "DeadTypeTest.res", line 3, characters 2-5
+  File "DeadTypeTest.res", line 3, characters 4-5
   t.B is a variant case which is never constructed
   <-- line 3
     | @dead("t.B") B
@@ -3116,13 +3116,13 @@ File References
   @dead("+a") let a = A
 
   Warning Dead Type
-  File "DeadTypeTest.res", line 10, characters 2-13
+  File "DeadTypeTest.res", line 10, characters 4-13
   deadType.InNeither is a variant case which is never constructed
   <-- line 10
     | @dead("deadType.InNeither") InNeither
 
   Warning Dead Type
-  File "DeadTypeTest.resi", line 3, characters 2-5
+  File "DeadTypeTest.resi", line 3, characters 4-5
   t.B is a variant case which is never constructed
   <-- line 3
     | @dead("t.B") B
@@ -3134,7 +3134,7 @@ File References
   @dead("+a") let a: t
 
   Warning Dead Type
-  File "DeadTypeTest.resi", line 10, characters 2-13
+  File "DeadTypeTest.resi", line 10, characters 4-13
   deadType.InNeither is a variant case which is never constructed
   <-- line 10
     | @dead("deadType.InNeither") InNeither
@@ -3164,7 +3164,7 @@ File References
   @dead("+valueDead") let valueDead: int
 
   Warning Dead Type
-  File "Docstrings.res", line 61, characters 2-5
+  File "Docstrings.res", line 61, characters 4-5
   t.B is a variant case which is never constructed
   <-- line 61
     | @dead("t.B") B
@@ -4000,7 +4000,7 @@ File References
     | @dead("variant.I") I(int)
 
   Warning Dead Type
-  File "ImportJsValue.res", line 68, characters 2-13
+  File "ImportJsValue.res", line 68, characters 4-13
   variant.S is a variant case which is never constructed
   <-- line 68
     | @dead("variant.S") S(string)
@@ -4144,7 +4144,7 @@ File References
       | @dead("Universe.variant.A") A
 
   Warning Dead Type
-  File "NestedModules.res", line 47, characters 4-15
+  File "NestedModules.res", line 47, characters 6-15
   Universe.variant.B is a variant case which is never constructed
   <-- line 47
       | @dead("Universe.variant.B") B(string)
@@ -4184,7 +4184,7 @@ File References
   type variant = | @dead("variant.A") A | B(int)|C
 
   Warning Dead Type
-  File "Newsyntax.res", line 10, characters 17-25
+  File "Newsyntax.res", line 10, characters 19-25
   variant.B is a variant case which is never constructed
   <-- line 10
   type variant = | @dead("variant.A") A | @dead("variant.B") B(int)|C
@@ -4388,7 +4388,7 @@ File References
     | @dead("typeWithVars.A") A('x, 'y)
 
   Warning Dead Type
-  File "Types.res", line 13, characters 2-9
+  File "Types.res", line 13, characters 4-9
   typeWithVars.B is a variant case which is never constructed
   <-- line 13
     | @dead("typeWithVars.B") B('z)
@@ -4406,7 +4406,7 @@ File References
     | @dead("opaqueVariant.A") A
 
   Warning Dead Type
-  File "Types.res", line 57, characters 2-5
+  File "Types.res", line 57, characters 4-5
   opaqueVariant.B is a variant case which is never constructed
   <-- line 57
     | @dead("opaqueVariant.B") B
@@ -4476,7 +4476,7 @@ File References
     | @dead("result1.Ok") Ok('a)
 
   Warning Dead Type
-  File "Variants.res", line 103, characters 2-13
+  File "Variants.res", line 103, characters 4-13
   result1.Error is a variant case which is never constructed
   <-- line 103
     | @dead("result1.Error") Error('b)
@@ -4488,13 +4488,13 @@ File References
     | @dead("simpleVariant.A") A
 
   Warning Dead Type
-  File "VariantsWithPayload.res", line 50, characters 2-5
+  File "VariantsWithPayload.res", line 50, characters 4-5
   simpleVariant.B is a variant case which is never constructed
   <-- line 50
     | @dead("simpleVariant.B") B
 
   Warning Dead Type
-  File "VariantsWithPayload.res", line 51, characters 2-5
+  File "VariantsWithPayload.res", line 51, characters 4-5
   simpleVariant.C is a variant case which is never constructed
   <-- line 51
     | @dead("simpleVariant.C") C
@@ -4506,25 +4506,25 @@ File References
     | @dead("variantWithPayloads.A") @genType.as("ARenamed") A
 
   Warning Dead Type
-  File "VariantsWithPayload.res", line 59, characters 2-10
+  File "VariantsWithPayload.res", line 59, characters 4-10
   variantWithPayloads.B is a variant case which is never constructed
   <-- line 59
     | @dead("variantWithPayloads.B") B(int)
 
   Warning Dead Type
-  File "VariantsWithPayload.res", line 60, characters 2-15
+  File "VariantsWithPayload.res", line 60, characters 4-15
   variantWithPayloads.C is a variant case which is never constructed
   <-- line 60
     | @dead("variantWithPayloads.C") C(int, int)
 
   Warning Dead Type
-  File "VariantsWithPayload.res", line 61, characters 2-17
+  File "VariantsWithPayload.res", line 61, characters 4-17
   variantWithPayloads.D is a variant case which is never constructed
   <-- line 61
     | @dead("variantWithPayloads.D") D((int, int))
 
   Warning Dead Type
-  File "VariantsWithPayload.res", line 62, characters 2-23
+  File "VariantsWithPayload.res", line 62, characters 4-23
   variantWithPayloads.E is a variant case which is never constructed
   <-- line 62
     | @dead("variantWithPayloads.E") E(int, string, int)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "dune build",
-    "build406": "cp src/dune src/dune.saved && cp src/dune.406 src/dune && npm run build && mv src/dune.saved src/dune",
+    "build406": "cp src/dune src/dune.saved && cp src/dune.406 src/dune && npm run build && mv src/dune.saved src/dune || mv src/dune.saved src/dune",
     "clean": "dune clean -p reanalyze",
     "test": "node ./scripts/run_integration_tests.js",
     "install:examples": "(cd examples/deadcode && npm install) & (cd examples/termination && npm install)",

--- a/src/DeadType.ml
+++ b/src/DeadType.ml
@@ -90,10 +90,10 @@ let addDeclaration ~(typeId : CL.Ident.t)
     (typeId |> CL.Ident.name |> Name.create)
     :: (currentModulePath.path @ [!Common.currentModuleName])
   in
-  let processTypeLabel ?(offset = Nothing) typeLabelName ~declKind
+  let processTypeLabel ?(posAdjustment = Nothing) typeLabelName ~declKind
       ~(loc : CL.Location.t) =
     addDeclaration_ ~declKind ~path:pathToType ~loc
-      ~moduleLoc:currentModulePath.loc ~offset typeLabelName;
+      ~moduleLoc:currentModulePath.loc ~posAdjustment typeLabelName;
     addTypeDependenciesAcrossFiles ~pathToType ~loc ~typeLabelName;
     addTypeDependenciesInnerModule ~pathToType ~loc ~typeLabelName;
     TypeLabels.add (typeLabelName :: pathToType) loc
@@ -108,13 +108,13 @@ let addDeclaration ~(typeId : CL.Ident.t)
   | Type_variant _ ->
     List.iteri
       (fun i {CL.Types.cd_id; cd_loc} ->
-        let offset =
+        let posAdjustment =
           (* In Res the variant loc can include the | and spaces after it *)
           if !Cli.json && Log_.posLanguage cd_loc.loc_start = Res then
             if i = 0 then FirstVariant else OtherVariant
           else Nothing
         in
         CL.Ident.name cd_id |> Name.create
-        |> processTypeLabel ~declKind:VariantCase ~loc:cd_loc ~offset)
+        |> processTypeLabel ~declKind:VariantCase ~loc:cd_loc ~posAdjustment)
       (Compat.getTypeVariant typeKind)
   | _ -> ()

--- a/src/DeadType.ml
+++ b/src/DeadType.ml
@@ -110,7 +110,7 @@ let addDeclaration ~(typeId : CL.Ident.t)
       (fun i {CL.Types.cd_id; cd_loc} ->
         let posAdjustment =
           (* In Res the variant loc can include the | and spaces after it *)
-          if !Cli.json && Log_.posLanguage cd_loc.loc_start = Res then
+          if Log_.posLanguage cd_loc.loc_start = Res then
             if i = 0 then FirstVariant else OtherVariant
           else Nothing
         in


### PR DESCRIPTION
Special treatment for variants location in json output.
    
The location of variants declarations in the typed tree includes the "|" and whatever spaces are there.
This complicates adding annotations that need to handle a number of special cases.    

E.g.

```rescript
type v = A | B | C
```
The locations are as follows: `A` and `| B` and `| C`.
    
Because of this issue https://github.com/rescript-lang/syntax/issues/506 the case of `A` needs to be special-cased by adding `|`.
    
For `B` and `C` we take the convention of adding the annotation 2 characters after the reported location. Which is not good for `A|B|C` but works well on formatted code.