### PR TITLE
Specify a build target for native projects

### DIFF
--- a/src/Common.ml
+++ b/src/Common.ml
@@ -1,9 +1,6 @@
 let currentSrc = ref ""
-
 let currentModule = ref ""
-
 let currentModuleName = ref ("" |> Name.create)
-
 let runConfig = RunConfig.runConfig
 
 (* Location printer: `filename:line: ' *)
@@ -16,18 +13,14 @@ let posToString (pos : Lexing.position) =
 
 module Cli = struct
   let debug = ref false
-
   let ci = ref false
 
   (** The command was a -cmt variant (e.g. -exception-cmt) *)
   let cmtCommand = ref false
 
   let experimental = ref false
-
   let json = ref false
-
   let write = ref false
-
   let exitCode = ref false
 
   (* names to be considered live values *)
@@ -39,6 +32,9 @@ module Cli = struct
 
   (* paths of files to exclude from analysis *)
   let excludePaths = ref ([] : string list)
+
+  (* path of build-generated files for native projects *)
+  let nativeBuildTarget = ref "_build/default/"
 end
 
 module StringSet = Set.Make (String)
@@ -56,7 +52,6 @@ module FileHash = struct
     type t = string
 
     let hash (x : t) = Hashtbl.hash x
-
     let equal (x : t) y = x = y
   end)
 end

--- a/src/Common.ml
+++ b/src/Common.ml
@@ -34,7 +34,7 @@ module Cli = struct
   let excludePaths = ref ([] : string list)
 
   (* path of build-generated files for native projects *)
-  let nativeBuildTarget = ref "_build/default/"
+  let nativeBuildTarget = ref ""
 end
 
 module StringSet = Set.Make (String)

--- a/src/Common.ml
+++ b/src/Common.ml
@@ -34,7 +34,7 @@ module Cli = struct
   let excludePaths = ref ([] : string list)
 
   (* path of build-generated files for native projects *)
-  let nativeBuildTarget = ref ""
+  let nativeBuildTarget = ref (None : string option)
 end
 
 module StringSet = Set.Make (String)

--- a/src/FindSourceFile.ml
+++ b/src/FindSourceFile.ml
@@ -1,7 +1,11 @@
 let rec interface items =
   match items with
   | {CL.Typedtree.sig_loc} :: rest -> (
-    match not (Sys.file_exists sig_loc.loc_start.pos_fname) with
+    match
+      not
+        (Sys.file_exists
+           (!Common.Cli.nativeBuildTarget ^ sig_loc.loc_start.pos_fname))
+    with
     | true -> interface rest
     | false -> Some sig_loc.loc_start.pos_fname)
   | [] -> None
@@ -9,7 +13,11 @@ let rec interface items =
 let rec implementation items =
   match items with
   | {CL.Typedtree.str_loc} :: rest -> (
-    match not (Sys.file_exists str_loc.loc_start.pos_fname) with
+    match
+      not
+        (Sys.file_exists
+           (!Common.Cli.nativeBuildTarget ^ str_loc.loc_start.pos_fname))
+    with
     | true -> implementation rest
     | false -> Some str_loc.loc_start.pos_fname)
   | [] -> None

--- a/src/FindSourceFile.ml
+++ b/src/FindSourceFile.ml
@@ -1,10 +1,14 @@
+(** Prepend nativeBuildTarget to fname when provided (-native-build-target) *)
+let nativeFilePath fname =
+  match !Common.Cli.nativeBuildTarget with
+  | None -> fname
+  | Some nativeBuildTarget -> Filename.concat nativeBuildTarget fname
+
 let rec interface items =
   match items with
   | {CL.Typedtree.sig_loc} :: rest -> (
     match
-      not
-        (Sys.file_exists
-           (!Common.Cli.nativeBuildTarget ^ sig_loc.loc_start.pos_fname))
+      not (Sys.file_exists (nativeFilePath sig_loc.loc_start.pos_fname))
     with
     | true -> interface rest
     | false -> Some sig_loc.loc_start.pos_fname)
@@ -14,9 +18,7 @@ let rec implementation items =
   match items with
   | {CL.Typedtree.str_loc} :: rest -> (
     match
-      not
-        (Sys.file_exists
-           (!Common.Cli.nativeBuildTarget ^ str_loc.loc_start.pos_fname))
+      not (Sys.file_exists (nativeFilePath str_loc.loc_start.pos_fname))
     with
     | true -> implementation rest
     | false -> Some str_loc.loc_start.pos_fname)

--- a/src/Reanalyze.ml
+++ b/src/Reanalyze.ml
@@ -153,6 +153,9 @@ let cli () =
         String (fun s -> setException (Some s)),
         "root_path Experimental exception analysis for all the .cmt files \
          under the root path" );
+      ( "-native-build-target",
+        String (fun s -> Common.Cli.nativeBuildTarget := s),
+        "A path for the build target (defaults to _build/default/)" );
       ( "-exclude-paths",
         String
           (fun s ->

--- a/src/Reanalyze.ml
+++ b/src/Reanalyze.ml
@@ -154,7 +154,7 @@ let cli () =
         "root_path Experimental exception analysis for all the .cmt files \
          under the root path" );
       ( "-native-build-target",
-        String (fun s -> Common.Cli.nativeBuildTarget := s),
+        String (fun s -> Common.Cli.nativeBuildTarget := Some s),
         "A path for the build target, defaults to ''. Can be useful for native \
          projects that use dune to set this to '_build/default'" );
       ( "-exclude-paths",

--- a/src/Reanalyze.ml
+++ b/src/Reanalyze.ml
@@ -155,7 +155,8 @@ let cli () =
          under the root path" );
       ( "-native-build-target",
         String (fun s -> Common.Cli.nativeBuildTarget := s),
-        "A path for the build target (defaults to _build/default/)" );
+        "A path for the build target, defaults to ''. Can be useful for native \
+         projects that use dune to set this to '_build/default'" );
       ( "-exclude-paths",
         String
           (fun s ->


### PR DESCRIPTION
See #174 

This makes it possible to properly analyze native projects that generate
new files, e.g., via ocamlyacc.