### PR TITLE
Update EXCEPTION.md

### DIFF
--- a/EXCEPTION.md
+++ b/EXCEPTION.md
@@ -61,7 +61,7 @@ let stringMake3 = @doesNotRaise String.make(12, ' ')
 
 ## Limitations
 
-- The libraries currently modeled are limited to `Array`, `Buffer`, `Bytes`, `Char`, `Filename`, `Hashtbl`, `List`, `Pervasives`, `Str`, `String` from the standard library, and `bs-json`, and `Json` from `Js`. Models are currently vendored in the analysis, and are easy to add (see [`src/ExnLib.res`](src/ExnLib.res))
+- The libraries currently modeled are limited to `Array`, `Buffer`, `Bytes`, `Char`, `Filename`, `Hashtbl`, `List`, `Pervasives`, `Str`, `String` from the standard library, and `bs-json`, and `Json` from `Js`. Models are currently vendored in the analysis, and are easy to add (see [`src/ExnLib.ml`](src/ExnLib.ml))
 - Generic exceptions are not understood by the analysis. For example `exn` is not recognized below (only concrete exceptions are):
 
 ```rescript


### PR DESCRIPTION
This fixes a broken link (from `.res` to `.ml`).