### PR TITLE
Fix first class module detection when a type alias is used for the module type

### DIFF
--- a/examples/deadcode/src/TestFirstClassModules.bs.js
+++ b/examples/deadcode/src/TestFirstClassModules.bs.js
@@ -17,10 +17,15 @@ function convertFirstClassModuleWithTypeEquations(x) {
   return x;
 }
 
+function convertFirstClassModuleWithTypeEquationsUsingAlias(x) {
+  return x;
+}
+
 export {
   convert ,
   convertInterface ,
   convertRecord ,
   convertFirstClassModuleWithTypeEquations ,
+  convertFirstClassModuleWithTypeEquationsUsingAlias ,
 }
 /* No side effect */

--- a/examples/deadcode/src/TestFirstClassModules.gen.tsx
+++ b/examples/deadcode/src/TestFirstClassModules.gen.tsx
@@ -22,3 +22,5 @@ export const convertInterface: (x:FirstClassModulesInterface_firstClassModule) =
 export const convertRecord: (x:FirstClassModulesInterface_record) => FirstClassModulesInterface_record = TestFirstClassModulesBS.convertRecord;
 
 export const convertFirstClassModuleWithTypeEquations: <T1,T2>(x:{ readonly out: ((_1:T1) => T1); readonly Inner: { readonly inn: ((_1:T2) => T2) } }) => { readonly out: (_1:T1) => T1; readonly Inner: { readonly inn: (_1:T2) => T2 } } = TestFirstClassModulesBS.convertFirstClassModuleWithTypeEquations;
+
+export const convertFirstClassModuleWithTypeEquationsUsingAlias: <T1,T2>(x:firstClassModuleWithTypeEquations<T1,T2>) => firstClassModuleWithTypeEquations<T1,T2> = TestFirstClassModulesBS.convertFirstClassModuleWithTypeEquationsUsingAlias;

--- a/examples/deadcode/src/TestFirstClassModules.res
+++ b/examples/deadcode/src/TestFirstClassModules.res
@@ -29,3 +29,8 @@ let convertFirstClassModuleWithTypeEquations = (
   x: module(MT with type Inner.inner = i and type outer = o),
 ) => x
 
+@genType
+let convertFirstClassModuleWithTypeEquationsUsingAlias = (
+  type o i,
+  x: firstClassModuleWithTypeEquations<i, o>,
+) => x

--- a/examples/deadcode/src/deadcode.txt
+++ b/examples/deadcode/src/deadcode.txt
@@ -1479,10 +1479,12 @@
   addValueDeclaration +convertInterface TestFirstClassModules.res:5:4 path:+TestFirstClassModules
   addValueDeclaration +convertRecord TestFirstClassModules.res:8:4 path:+TestFirstClassModules
   addValueDeclaration +convertFirstClassModuleWithTypeEquations TestFirstClassModules.res:27:4 path:+TestFirstClassModules
+  addValueDeclaration +convertFirstClassModuleWithTypeEquationsUsingAlias TestFirstClassModules.res:33:4 path:+TestFirstClassModules
   addValueReference TestFirstClassModules.res:2:4 --> TestFirstClassModules.res:2:15
   addValueReference TestFirstClassModules.res:5:4 --> TestFirstClassModules.res:5:24
   addValueReference TestFirstClassModules.res:8:4 --> TestFirstClassModules.res:8:21
   addValueReference TestFirstClassModules.res:27:4 --> TestFirstClassModules.res:29:2
+  addValueReference TestFirstClassModules.res:33:4 --> TestFirstClassModules.res:35:2
   Scanning TestImmutableArray.cmt Source:TestImmutableArray.res
   addValueDeclaration +testImmutableArrayGet TestImmutableArray.res:2:4 path:+TestImmutableArray
   addValueDeclaration +testBeltArrayGet TestImmutableArray.res:12:4 path:+TestImmutableArray
@@ -2254,6 +2256,7 @@ File References
   Live Value +TestEmitInnerModules.Outer.Medium.Inner.+y: 0 references () [0]
   Live Value +TestEmitInnerModules.Inner.+y: 0 references () [0]
   Live Value +TestEmitInnerModules.Inner.+x: 0 references () [0]
+  Live Value +TestFirstClassModules.+convertFirstClassModuleWithTypeEquationsUsingAlias: 0 references () [0]
   Live Value +TestFirstClassModules.+convertFirstClassModuleWithTypeEquations: 0 references () [0]
   Live Value +TestFirstClassModules.+convertRecord: 0 references () [0]
   Live Value +TestFirstClassModules.+convertInterface: 0 references () [0]

--- a/src/DeadValue.ml
+++ b/src/DeadValue.ml
@@ -39,12 +39,13 @@ let collectValueBinding super self (vb : CL.Typedtree.value_binding) =
       in
       let currentModulePath = ModulePath.getCurrent () in
       let path = currentModulePath.path @ [!Common.currentModuleName] in
-      let isFirstClassModule =
-        match Compat.get_desc vb.vb_expr.exp_type with
+      let rec isFirstClassModule (type_expr: CL.Types.type_expr) : bool =
+        match Compat.get_desc type_expr with
         | Tpackage _ -> true
+        | Tconstr (p, ts, _) -> List.exists isFirstClassModule ts || String.starts_with ~prefix:(CL.Path.name p) "moduleAlias"
         | _ -> false
       in
-      (if (not exists) && not isFirstClassModule then
+      (if (not exists) && not (isFirstClassModule vb.vb_expr.exp_type) then
        (* This is never toplevel currently *)
        let isToplevel = oldLastBinding = CL.Location.none in
        let sideEffects = SideEffects.checkExpr vb.vb_expr in


### PR DESCRIPTION
I ran across a case where false positives were being generated for first class modules. In particular the false positive was only generated if a type alias was used for the module's type. I have recreated a minimal reproduction of the issue below and have implemented a fix for this false positive. I'm not well versed in OCaml or the overall structure of Reanalyze so any feedback would be appreciated!

## Example First Class Module

```res
module type ModuleType = {
  type t
}

module MakeWithType = (A: ModuleType): (ModuleType with type t = A.t) => {
  type t = A.t
}

let main = () => {
  let moduleA: module(ModuleType with type t = int) = module(
    MakeWithType({
      type t = int
    })
  )

  let module(A) = moduleA

  let intA: A.t = 1

  Js.log(intA)
}

main()
```

## Example First Class Module with False Positive

```res
module type ModuleType = {
  type t
}

module MakeWithType = (A: ModuleType): (ModuleType with type t = A.t) => {
  type t = A.t
}

type moduleAlias<'a> = module(ModuleType with type t = 'a)

let main = () => {
  // Marked as dead (transitively) due to type alias
  let moduleA: moduleAlias<int> = module(
    MakeWithType({
      type t = int
    })
  )
 
  // Marked as dead (false positive)
  let module(A) = moduleA

  // Live usage of module A
  let intA: A.t = 1

  Js.log(intA)
}

main()
```

